### PR TITLE
Change write_slice() to copy_from_slice()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@ impl OwnedCursor {
 
         // SAFETY: we do not de-initialize any of the elements of the slice
         unsafe {
-            MaybeUninit::write_slice(&mut self.as_mut()[..data.len()], data);
+            MaybeUninit::copy_from_slice(&mut self.as_mut()[..data.len()], data);
         }
 
         // SAFETY: We just added the entire contents of data.


### PR DESCRIPTION
Build was failed in current main

```
owned-buf$ cargo check
    Checking owned-buf v0.2.0 (/home/ys/Source/Projects/rust/owned-buf)
error[E0599]: no function or associated item named `write_slice` found for union `MaybeUninit` in the current scope
   --> src/lib.rs:535:26
    |
535 |             MaybeUninit::write_slice(&mut self.as_mut()[..data.len()], data);
    |                          ^^^^^^^^^^^ function or associated item not found in `MaybeUninit<_>`
    |
note: if you're trying to build a new `MaybeUninit<_>` consider using one of the following associated functions:
      MaybeUninit::<T>::new
      MaybeUninit::<T>::uninit
      MaybeUninit::<T>::zeroed
   --> /home/ys/Source/.asdf/installs/rust/nightly/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/mem/maybe_uninit.rs:290:5
    |
290 |     pub const fn new(val: T) -> MaybeUninit<T> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
313 |     pub const fn uninit() -> MaybeUninit<T> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
402 |     pub const fn zeroed() -> MaybeUninit<T> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `owned-buf` (lib) due to 1 previous error
```

To follow API update[1], change MaybeUninit::write_slice() to copy_from_slice().

[1]: https://github.com/rust-lang/rust/pull/116385